### PR TITLE
Support for Multiple Content types

### DIFF
--- a/archetypes/blogs.md
+++ b/archetypes/blogs.md
@@ -1,0 +1,13 @@
+---
+title: '{{ replace .File.ContentBaseName "-" " " | title }}'
+date: '{{ .Date }}'
+draft: false
+author: 'Jairaj Kumar'
+categories: []
+tags: []
+description: ''
+featured: 0  # 0 means not featured, higher numbers (e.g., 1.1, 1.2) will be shown in order
+toc: true
+slug: '{{ .File.ContentBaseName }}'
+---
+

--- a/archetypes/opinions.md
+++ b/archetypes/opinions.md
@@ -1,0 +1,12 @@
+---
+title: '{{ replace .File.ContentBaseName "-" " " | title }}'
+date: '{{ .Date }}'
+draft: false
+author: 'Jairaj Kumar'
+opinion_categories: []
+opinion_tags: []
+description: ''
+toc: true
+slug: '{{ .File.ContentBaseName }}'
+---
+

--- a/archetypes/opinions.md
+++ b/archetypes/opinions.md
@@ -3,6 +3,7 @@ title: '{{ replace .File.ContentBaseName "-" " " | title }}'
 date: '{{ .Date }}'
 draft: false
 author: 'Jairaj Kumar'
+excludeFromSearch: true # This is to exclude this post from search results
 opinion_categories: []
 opinion_tags: []
 description: ''

--- a/content/README.md
+++ b/content/README.md
@@ -23,7 +23,8 @@ params:
       taxonomies: ["news_categories", "news_tags"]
 ```
 
-**Note on `taxonomies` field:** This tells the footer which taxonomy pages belong to this section. When viewing `/news-categories/` or `/news-tags/`, the footer will show "Latest News" recent posts instead of defaulting to blogs.
+**Note on `taxonomies` field:** This tells the footer which taxonomy pages belong to this section. When viewing `/news_categories/` or `/news_tags/`, the footer will show "Latest News" recent posts instead of defaulting to blogs.
+Use same in archtypes/template is must
 
 #### 1b. Add to Navigation Menu
 

--- a/content/README.md
+++ b/content/README.md
@@ -124,3 +124,30 @@ hugo new news/my-first-news.md
 | Blogs | `content/blogs/` | `archetypes/blogs.md` | `categories` |
 | Opinions | `content/opinions/` | `archetypes/opinions.md` | `opinion_categories` |
 | News | `content/news/` | `archetypes/news.md` | `news_categories` |
+
+---
+
+## Adding a Post to Featured Section
+
+Posts from **any section** can appear in the homepage Featured section.
+
+**Required front matter:**
+
+```yaml
+categories: ["featured"]
+featured: 5  # Higher number = appears first on homepage
+```
+
+**Note:** The `featured` number is **only used for homepage ordering**. On the `/categories/featured/` page, all featured posts are shown sorted by this value.
+
+**Example:** Adding an opinion to featured:
+
+```yaml
+---
+title: 'My Opinion Post'
+opinion_categories: ["thoughts"]
+opinion_tags: ["design"]
+categories: ["featured"]   # Add to featured
+featured: 5                 # Homepage order (higher = first)
+---
+```

--- a/content/README.md
+++ b/content/README.md
@@ -1,0 +1,122 @@
+# How to Add a New Content Section
+
+This guide explains how to add a new content section (like `/news`, `/tutorials`, etc.) to the site.
+
+---
+
+## Example: Adding `/news` Section
+
+### Step 1: Update `hugo.yaml`
+
+#### 1a. Add Section Config
+
+**Why:** This tells the footer what title and button text to show when viewing news pages.
+
+**What it does:** When you're on a news page, the footer will show "Latest News" instead of "Recent Posts".
+
+```yaml
+params:
+  contentSections:
+    news:
+      recentTitle: "Latest News"
+      viewAllText: "View All News"
+```
+
+#### 1b. Add to Navigation Menu
+
+**Why:** Makes the section accessible from the main navigation bar.
+
+**What it does:** Adds a "News" link in the header that takes users to `/news`.
+
+```yaml
+Menus:
+  main:
+    - identifier: news
+      name: News
+      url: /news
+      weight: 4
+```
+
+#### 1c. Add Taxonomies (Optional)
+
+**Why:** Creates separate categories/tags for news that won't mix with blogs or opinions.
+
+**What it does:** News posts can have `news_categories: ["breaking"]` without affecting blog categories.
+
+```yaml
+taxonomies:
+  news_tag: news_tags
+  news_category: news_categories
+```
+
+---
+
+### Step 2: Create Content Directory
+
+**Why:** Hugo needs a folder to store the news posts.
+
+**What it does:** Creates the `/news` URL and houses all news markdown files.
+
+```bash
+mkdir content/news
+```
+
+#### Create Index File
+
+**Why:** Sets the page title for the news list page.
+
+**What it does:** When visiting `/news`, the page will show "News" as the header.
+
+Create `content/news/_index.md`:
+
+```markdown
+---
+title: "News"
+---
+```
+
+---
+
+### Step 3: Create Archetype
+
+**Why:** Provides a template for new posts with correct front matter fields.
+
+**What it does:** When you run `hugo new news/post.md`, it auto-populates the correct fields.
+
+Create `archetypes/news.md`:
+
+```markdown
+---
+title: '{{ replace .File.ContentBaseName "-" " " | title }}'
+date: '{{ .Date }}'
+draft: false
+author: 'Jairaj Kumar'
+news_categories: []
+news_tags: []
+description: ''
+toc: true
+slug: '{{ .File.ContentBaseName }}'
+---
+```
+
+---
+
+### Step 4: Create New Posts
+
+**Why:** Now you can easily create properly-formatted news posts.
+
+**What it does:** Creates a new file with all the correct front matter already filled in.
+
+```bash
+hugo new news/my-first-news.md
+```
+
+---
+
+## Quick Reference
+
+| Section | Content Dir | Archetype | Categories Field |
+|---------|-------------|-----------|------------------|
+| Blogs | `content/blogs/` | `archetypes/blogs.md` | `categories` |
+| Opinions | `content/opinions/` | `archetypes/opinions.md` | `opinion_categories` |
+| News | `content/news/` | `archetypes/news.md` | `news_categories` |

--- a/content/README.md
+++ b/content/README.md
@@ -20,7 +20,10 @@ params:
     news:
       recentTitle: "Latest News"
       viewAllText: "View All News"
+      taxonomies: ["news_categories", "news_tags"]
 ```
+
+**Note on `taxonomies` field:** This tells the footer which taxonomy pages belong to this section. When viewing `/news-categories/` or `/news-tags/`, the footer will show "Latest News" recent posts instead of defaulting to blogs.
 
 #### 1b. Add to Navigation Menu
 

--- a/content/README.md
+++ b/content/README.md
@@ -24,7 +24,9 @@ params:
 ```
 
 **Note on `taxonomies` field:** This tells the footer which taxonomy pages belong to this section. When viewing `/news_categories/` or `/news_tags/`, the footer will show "Latest News" recent posts instead of defaulting to blogs.
-Use same in archtypes/template is must
+Use same in archetypes/template is a must.
+
+> ⚠️ **Important:** If you don't add your section to `contentSections`, the footer will fall back to showing "Recent Blogs" instead of your section's posts. This can be intentional for [unlisted/secret sections](#creating-an-unlisted-secret-section).
 
 #### 1b. Add to Navigation Menu
 
@@ -149,5 +151,135 @@ opinion_categories: ["thoughts"]
 opinion_tags: ["design"]
 categories: ["featured"]   # Add to featured
 featured: 5                 # Homepage order (higher = first)
+---
+```
+
+---
+
+## Creating an Unlisted (Secret) Section
+
+Use this when you want posts that are **only accessible via direct link** - great for sharing specific content privately without exposing other posts in the same section.
+
+### What "Unlisted" Means
+
+| Item | Behavior |
+|------|----------|
+| Section list page (`/section-name/`) | ❌ Returns 404 |
+| Individual posts (`/section-name/post/`) | ✅ Accessible via direct link |
+| "Recent Posts" in footer | ❌ Never shows posts from this section |
+| Menu navigation | ❌ No link in menu |
+| Search | ❌ Can be excluded (optional) |
+
+### Example: Making `/opinions` Unlisted
+
+#### Step 1: Mark Section as Draft
+
+Edit `content/opinions/_index.md`:
+
+```yaml
+---
+title: "Opinions"
+draft: true
+---
+```
+
+> **What this does:** The URL `/opinions/` will return 404. Individual posts remain accessible.
+
+#### Step 2: Remove from `contentSections`
+
+In `hugo.yaml`, comment out or remove the section from `contentSections`:
+
+```yaml
+params:
+  contentSections:
+    blogs:
+      recentTitle: "Recent Posts"
+      viewAllText: "View All Blogs"
+      taxonomies: ["categories", "tags"]
+    # opinions:                              # ← Comment out or remove
+    #   recentTitle: "Recent Opinions"
+    #   viewAllText: "View All Opinions"
+    #   taxonomies: ["opinion_categories", "opinion_tags"]
+```
+
+> **What this does:** "Recent Opinions" will never appear in the footer. When viewing an opinion post, the footer falls back to showing "Recent Posts" (blogs) instead.
+
+#### Step 3: Ensure Menu Link is Removed
+
+In `hugo.yaml`, make sure the section is not in the menu:
+
+```yaml
+Menus:
+  main:
+    - identifier: blog
+      name: Blogs
+      url: /blogs
+      weight: 1
+    # - identifier: opinions  # ← Keep this commented out
+    #   name: Opinions
+    #   url: /opinions
+    #   weight: 2
+```
+
+#### Step 4 (Optional): Exclude from Search
+
+Add this to individual posts to exclude from search:
+
+```yaml
+---
+title: 'My Secret Opinion'
+draft: false
+excludeFromSearch: true   # ← Excludes from site search
+---
+```
+
+### Summary: Unlisted Section Checklist
+
+| Step | Location | Change |
+|------|----------|--------|
+| 1 | `content/section/_index.md` | Add `draft: true` |
+| 2 | `hugo.yaml` | Remove section from `contentSections` |
+| 3 | `hugo.yaml` | Remove/comment section from `Menus.main` |
+| 4 | Individual posts (optional) | Add `excludeFromSearch: true` |
+
+### How It Works Internally
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  User visits /opinions/my-secret-post/                          │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  1. Post is visible (draft: false on the post itself)           │
+│                                                                  │
+│  2. Footer template looks for "opinions" in contentSections     │
+│     → Not found!                                                 │
+│                                                                  │
+│  3. Falls back to footer.recentPosts.path → "blogs"             │
+│                                                                  │
+│  4. Shows "Recent Posts" from blogs section                     │
+│     → No opinions exposed!                                       │
+│                                                                  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Important Notes
+
+> ⚠️ **Posts are still public!** Anyone with the direct link can access them. This is "security through obscurity" - suitable for non-sensitive content you just don't want discoverable.
+
+> 💡 **Cascade warning:** Do NOT use `cascade: draft: true` in `_index.md` - this will hide all individual posts too!
+
+```yaml
+# ❌ DON'T DO THIS (hides all posts)
+---
+title: "Opinions"
+draft: true
+cascade:
+  draft: true
+---
+
+# ✅ DO THIS (only hides section listing)
+---
+title: "Opinions"
+draft: true
 ---
 ```

--- a/content/opinions/_index.md
+++ b/content/opinions/_index.md
@@ -1,0 +1,3 @@
+---
+title: "Opinions"
+---

--- a/content/opinions/_index.md
+++ b/content/opinions/_index.md
@@ -1,3 +1,4 @@
 ---
 title: "Opinions"
+draft: true
 ---

--- a/content/opinions/android-oems-losing-plot.md
+++ b/content/opinions/android-oems-losing-plot.md
@@ -1,0 +1,51 @@
+---
+title: 'Android Oems Losing Plot'
+date: '2025-12-23T01:11:31+05:30'
+draft: false
+author: 'Jairaj Kumar'
+excludeFromSearch: true # This is to exclude this post from search results
+opinion_categories: []
+opinion_tags: []
+description: ''
+toc: true
+slug: 'android-oems-losing-plot'
+---
+
+Let’s be real for a second. For years, the "value flagship" space was Android’s fortress. If you wanted top-tier specs without selling a kidney, you bought a OnePlus, an iQOO, or a Xiaomi. But lately? I feel like Android manufacturers are intentionally shooting themselves in the foot.
+
+I watched a recent video by **GeekyRanjit** that perfectly articulated something I’ve been feeling for months: **Android pricing in India has lost its mind.**
+
+<!-- {{< youtube J2wo5xDzgS0 >}} -->
+
+### The "Value" Myth
+
+We are seeing new launches like the OnePlus 15 and iQOO 15 hitting the market at around **₹73,000**. Let that sink in. These are supposed to be the "affordable" alternatives to the ultra-premium tier.
+
+What’s worse is the massive price gap—sometimes nearly ₹20,000—between the Chinese and Indian pricing for the exact same device. We used to justify this with import duties and taxes, but at this scale? It feels like we are just being taken for a ride.
+
+### The iPhone 17 Curveball
+
+While Android OEMs were busy inflating their prices, Apple did something they almost never do: **they made the base iPhone practically perfect.**
+
+For the longest time, I couldn't recommend a non-Pro iPhone. They had 60Hz screens (in 2024!), slow charging, and measly 128GB base storage. But the new **iPhone 17** has flipped the script:
+
+* **120Hz ProMotion?** Finally here.
+* **Base Storage?** Bumped to 256GB.
+* **Screen Quality?** Identical to the Pro models (3000 nits brightness).
+
+Suddenly, the "Android advantage" of better specs for the price has evaporated. If you are sitting with a budget of ₹75,000, why would you buy a "value" Android that might get a green line issue in two years when you can get a fully loaded iPhone that will easily last you four or five?
+
+### The Longevity Problem
+
+This is the nail in the coffin for me. My friends with Android flagships often find themselves upgrading every 2–3 years because of battery degradation, buggy updates, or hardware failures. Meanwhile, an iPhone 12 Pro user is still cruising along comfortably.
+
+When you do the math, buying one ₹80,000 iPhone every 5 years is cheaper than buying two ₹70,000 Androids in the same period.
+
+### Conclusion
+
+It hurts to say this as an Android enthusiast, but the manufacturers have become arrogant. They are stripping down camera features on standard models (likely to push you to the "Pro" or "Ultra" variants) while stuffing the software with bloatware.
+
+Unless Android OEMs wake up and fix their pricing strategy, they are handing their market share to Apple on a silver platter. For the first time in years, the most logical recommendation for a regular user isn't a flagship killer—it's just the iPhone.
+
+
+---

--- a/content/opinions/simplicity_over_complexity.md
+++ b/content/opinions/simplicity_over_complexity.md
@@ -1,11 +1,12 @@
 ---
 title: 'Why Simplicity Beats Complexity in Software Design'
 date: '2025-12-21T03:43:00+05:30'
-draft: false
+draft: true
 author: 'Jairaj Kumar'
 excludeFromSearch: true # This is to exclude this post from search results
 opinion_categories: ["thoughts"]
 opinion_tags: ["software", "design"]
+slug: 'simplicity-over-complexity'
 description: 'A perspective on why simpler solutions often outperform complex ones'
 toc: true
 ---

--- a/content/opinions/simplicity_over_complexity.md
+++ b/content/opinions/simplicity_over_complexity.md
@@ -1,0 +1,40 @@
+---
+title: 'Why Simplicity Beats Complexity in Software Design'
+date: '2025-12-21T03:43:00+05:30'
+draft: false
+author: 'Jairaj Kumar'
+opinion_categories: ["thoughts"]
+opinion_tags: ["software", "design"]
+description: 'A perspective on why simpler solutions often outperform complex ones'
+toc: true
+---
+
+Here's an opinion that might be controversial: **the best code is the code you didn't write**.
+
+## The Complexity Trap
+
+We engineers love building things. We love elegant abstractions, clever patterns, and sophisticated architectures. But sometimes, in our pursuit of the "perfect" solution, we create systems that are:
+
+- Hard to understand
+- Difficult to debug
+- Expensive to maintain
+- Slow to modify
+
+## Simple > Clever
+
+I've learned that a straightforward, "boring" solution that everyone on the team can understand is almost always better than a clever one that only its author can maintain.
+
+> "Debugging is twice as hard as writing the code in the first place. Therefore, if you write the code as cleverly as possible, you are, by definition, not smart enough to debug it." — Brian Kernighan
+
+## My Rule of Thumb
+
+Before adding complexity, I ask myself:
+1. Will this still make sense in 6 months?
+2. Can a new team member understand this quickly?
+3. Does the added complexity solve a real, current problem?
+
+If the answer to any of these is "no," I simplify.
+
+---
+
+*This is a dummy opinion post to test the opinions section.*

--- a/content/opinions/simplicity_over_complexity.md
+++ b/content/opinions/simplicity_over_complexity.md
@@ -3,6 +3,7 @@ title: 'Why Simplicity Beats Complexity in Software Design'
 date: '2025-12-21T03:43:00+05:30'
 draft: false
 author: 'Jairaj Kumar'
+excludeFromSearch: true # This is to exclude this post from search results
 opinion_categories: ["thoughts"]
 opinion_tags: ["software", "design"]
 description: 'A perspective on why simpler solutions often outperform complex ones'

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -29,6 +29,8 @@ enableRobotsTXT: true
 taxonomies:
   tag: tags
   category: categories
+  opinion_tag: opinion_tags
+  opinion_category: opinion_categories
 
 #services:
   #googleAnalytics:
@@ -46,11 +48,16 @@ Menus:
       title: Blog posts
       url: /blogs
       weight: 1
+    - identifier: opinions
+      name: Opinions
+      title: Opinion pieces
+      url: /opinions
+      weight: 2
     - identifier: Categories # Uncomment if you plan to have categories
       name: Categories
       title: Categories
       url: /categories
-      weight: 2
+      weight: 3
     # - identifier: tags
     #   name: Tags
     #   title: Tags
@@ -64,6 +71,14 @@ Menus:
     # Add other menu items as needed
 
 params:
+  contentSections:
+    blogs:
+      recentTitle: "Recent Posts"
+      viewAllText: "View All Blogs"
+    opinions:
+      recentTitle: "Recent Opinions"
+      viewAllText: "View All Opinions"
+
   featuredBlogs:
     title: "Featured Posts"
     count: 3  # Number of featured posts to show

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -76,10 +76,10 @@ params:
       recentTitle: "Recent Posts"
       viewAllText: "View All Blogs"
       taxonomies: ["categories", "tags"]
-    opinions:
-      recentTitle: "Recent Opinions"
-      viewAllText: "View All Opinions"
-      taxonomies: ["opinion_categories", "opinion_tags"]
+    # opinions:
+    #   recentTitle: "Recent Opinions"
+    #   viewAllText: "View All Opinions"
+    #   taxonomies: ["opinion_categories", "opinion_tags"]
 
   featuredBlogs:
     title: "Featured Posts"

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -48,16 +48,16 @@ Menus:
       title: Blog posts
       url: /blogs
       weight: 1
-    - identifier: opinions
-      name: Opinions
-      title: Opinion pieces
-      url: /opinions
-      weight: 2
     - identifier: Categories # Uncomment if you plan to have categories
       name: Categories
       title: Categories
       url: /categories
-      weight: 3
+      weight: 2
+    # - identifier: opinions
+    #   name: Opinions
+    #   title: Opinion pieces
+    #   url: /opinions
+    #   weight: 3
     # - identifier: tags
     #   name: Tags
     #   title: Tags

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -75,9 +75,11 @@ params:
     blogs:
       recentTitle: "Recent Posts"
       viewAllText: "View All Blogs"
+      taxonomies: ["categories", "tags"]
     opinions:
       recentTitle: "Recent Opinions"
       viewAllText: "View All Opinions"
+      taxonomies: ["opinion_categories", "opinion_tags"]
 
   featuredBlogs:
     title: "Featured Posts"

--- a/layouts/_default/index.json
+++ b/layouts/_default/index.json
@@ -1,5 +1,7 @@
 {{- $.Scratch.Add "index" slice -}}
 {{- range .Site.RegularPages -}}
+{{- if not .Params.excludeFromSearch -}}
     {{- $.Scratch.Add "index" (dict "title" .Title "description" .Params.description "content" .Content "image" .Params.image "permalink" .Permalink) -}}
+{{- end -}}
 {{- end -}}
 {{- $.Scratch.Get "index" | jsonify -}}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -4,12 +4,18 @@
 {{ end }}
 
 {{ define "title" }}
-{{.Title }} | {{ .Site.Title }}
+{{/* Clean taxonomy titles by splitting on _ and using last element */}}
+{{ $parts := split .Title "_" }}
+{{ $cleanTitle := index $parts (sub (len $parts) 1) | title }}
+{{ $cleanTitle }} | {{ .Site.Title }}
 {{ end }}
 
 {{ define "main" }}
+{{/* Clean taxonomy titles for display */}}
+{{ $parts := split .Title "_" }}
+{{ $displayTitle := index $parts (sub (len (split .Title "_")) 1) | title }}
 <div class="container pt-5" id="list-page">
-    <h2 class="text-center pb-2">{{.Title}}</h2>
+    <h2 class="text-center pb-2">{{ $displayTitle }}</h2>
     <div class="row">
         {{ $pages := .Pages }}
         {{/* Check if this is a taxonomy term page for featured category */}}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -87,13 +87,20 @@
           </aside>
           {{ end }}
 
-          {{ $section := .Section }}
-          {{ $singularSection := strings.TrimSuffix "s" $section }}
-          {{ $tagsField := printf "%s_tags" $singularSection }}
+                    {{/* Find tags from contentSections taxonomies config */}}
+          {{ $sectionConfig := index .Site.Params.contentSections .Section }}
+          {{ $tagsField := "tags" }}
+          {{ $tagsUrl := "tags" }}
+          {{ if $sectionConfig }}
+          {{ range $sectionConfig.taxonomies }}
+          {{ if strings.Contains . "_tags" }}
+          {{ $tagsField = . }}
+          {{ $tagsUrl = . }}
+          {{ end }}
+          {{ end }}
+          {{ end }}
           {{ $currentTags := index .Params $tagsField }}
-          {{ if not $currentTags }}{{ $currentTags = .Params.tags }}{{ end }}
-          {{ $tagsUrl := cond $currentTags (printf "%s_tags" $singularSection) "tags" }}
-          {{ if eq $currentTags .Params.tags }}{{ $tagsUrl = "tags" }}{{ end }}
+          {{ if not $currentTags }}{{ $currentTags = .Params.tags }}{{ $tagsUrl = "tags" }}{{ end }}
           {{ if $currentTags }}
           <aside class="tags">
             <h5>{{ .Site.Params.terms.tags | default "Tags" }}</h5>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -87,19 +87,24 @@
           </aside>
           {{ end }}
 
-          {{ if .Params.tags }}
+          {{ $section := .Section }}
+          {{ $singularSection := strings.TrimSuffix "s" $section }}
+          {{ $tagsField := printf "%s_tags" $singularSection }}
+          {{ $currentTags := index .Params $tagsField }}
+          {{ if not $currentTags }}{{ $currentTags = .Params.tags }}{{ end }}
+          {{ $tagsUrl := cond $currentTags (printf "%s_tags" $singularSection) "tags" }}
+          {{ if eq $currentTags .Params.tags }}{{ $tagsUrl = "tags" }}{{ end }}
+          {{ if $currentTags }}
           <aside class="tags">
             <h5>{{ .Site.Params.terms.tags | default "Tags" }}</h5>
             <ul class="tags-ul list-unstyled list-inline">
-              {{range .Params.tags}}
-              <li class="list-inline-item"><a href="{{`tags` | relURL}}/{{.| urlize}}"
-                {{ if site.Params.singlePages.tags.openInNewTab | default true }}target="_blank"{{ end }}
-              >{{.}}</a></li>
+              {{range $currentTags}}
+              <li class="list-inline-item"><a href="{{ $tagsUrl | relURL}}/{{.| urlize}}" {{ if
+                  site.Params.singlePages.tags.openInNewTab | default true }}target="_blank" {{ end }}>{{.}}</a></li>
               {{end}}
             </ul>
           </aside>
           {{end}}
-
           {{ if .Params.socialShare | default .Site.Params.singlePages.socialShare | default true }}
           <aside class="social">
             <h5>{{ .Site.Params.terms.social | default "Social" }}</h5>

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -4,12 +4,18 @@
 {{ end }}
 
 {{ define "title" }}
-{{.Title }} | {{ .Site.Title }}
+{{/* Clean taxonomy titles by splitting on _ and using last element */}}
+{{ $parts := split .Title "_" }}
+{{ $cleanTitle := index $parts (sub (len $parts) 1) | title }}
+{{ $cleanTitle }} | {{ .Site.Title }}
 {{ end }}
 
 {{ define "main" }}
+{{/* Clean taxonomy titles for display */}}
+{{ $parts := split .Title "_" }}
+{{ $displayTitle := index $parts (sub (len $parts) 1) | title }}
 <div class="container pt-5" id="list-page">
-    <h2 class="text-center pb-2">{{.Title}}</h2>
+    <h2 class="text-center pb-2">{{ $displayTitle }}</h2>
     <div class="row">
         {{/* 1. Build a slice of Pages from the Sorted Terms */}}
         {{ $sortedPages := slice }}

--- a/layouts/partials/sections/featured-blogs.html
+++ b/layouts/partials/sections/featured-blogs.html
@@ -1,6 +1,6 @@
-{{ $featuredPosts := where .Site.RegularPages "Section" "blogs" }}
+{{ $featuredPosts := where .Site.RegularPages "Params.categories" "intersect" (slice "featured") }}
 {{ $featuredPosts = where $featuredPosts "Params.featured" ">" 0 }}
-{{ $featuredPosts = sort $featuredPosts "Params.featured" "desc" }}
+{{ $featuredPosts = sort $featuredPosts "Params.featured" "desc" "float" }}
 {{ $featuredCount := .Site.Params.featuredBlogs.count | default 3 }}
 {{ if gt (len $featuredPosts) 0 }}
 <!-- <link rel="stylesheet" href="{{ "css/list.css" | relURL }}" media="all"> -->

--- a/layouts/partials/sections/footer/recentBlogPosts.html
+++ b/layouts/partials/sections/footer/recentBlogPosts.html
@@ -1,11 +1,30 @@
-{{ $recentPostsPath := .Site.Params.footer.recentPosts.path | default "blogs" }}
-{{ $currentNumOfrecentPosts := len (where .Site.RegularPages "Type" $recentPostsPath) }} 
-{{ if and (not (and .IsSection (eq .Section $recentPostsPath))) (gt $currentNumOfrecentPosts 0) (.Site.Params.footer.recentPosts.enable | default false) }} 
+{{/* Dynamically determine section and load config from contentSections */}}
+{{ $currentSection := .Section }}
+{{ $sectionConfig := index .Site.Params.contentSections $currentSection }}
+
+{{/* Fallback to default blogs section if current section not configured */}}
+{{ if not $sectionConfig }}
+    {{ $currentSection = .Site.Params.footer.recentPosts.path | default "blogs" }}
+    {{ $sectionConfig = index .Site.Params.contentSections $currentSection }}
+{{ end }}
+
+{{/* Get section-specific config or use defaults */}}
+{{ $recentPostsPath := $currentSection }}
+{{ $recentPostsTitle := "Recent Posts" }}
+{{ $viewAllText := "View All" }}
+
+{{ if $sectionConfig }}
+    {{ $recentPostsTitle = $sectionConfig.recentTitle | default "Recent Posts" }}
+    {{ $viewAllText = $sectionConfig.viewAllText | default "View All" }}
+{{ end }}
+
+{{ $currentNumOfrecentPosts := len (where .Site.RegularPages "Type" $recentPostsPath) }}
+{{ if and (not (and .IsSection (eq .Section $recentPostsPath))) (gt $currentNumOfrecentPosts 0) (.Site.Params.footer.recentPosts.enable | default false) }}
 <div class="container py-3" id="recent-posts">
     {{ $recentPostsCount := .Site.Params.footer.recentPosts.count | default 3 }}
     {{ $recentPosts := where .Site.RegularPages "Section" $recentPostsPath | first $recentPostsCount }}
     <div class="h3 text-center text-secondary py-3">
-        {{ .Site.Params.footer.recentPosts.title | default "Recent Posts" }}
+        {{ $recentPostsTitle }}
     </div>
     <div class="row justify-content-center">
         {{ range $recentPosts }}
@@ -35,7 +54,7 @@
         {{ end }}
     </div>
     <div class="text-center pt-4">
-        <a href="{{ $recentPostsPath | relLangURL }}" class="btn btn-outline-primary rounded-pill">{{ .Site.Params.footer.recentPosts.viewAllText | default "View All Blogs" }}</a>
+        <a href="{{ $recentPostsPath | relLangURL }}" class="btn btn-outline-primary rounded-pill">{{ $viewAllText }}</a>
     </div>
 </div>
 {{ end }}

--- a/layouts/partials/sections/footer/recentBlogPosts.html
+++ b/layouts/partials/sections/footer/recentBlogPosts.html
@@ -1,5 +1,13 @@
 {{/* Dynamically determine section and load config from contentSections */}}
 {{ $currentSection := .Section }}
+
+{{/* Check if current page type matches any section's taxonomies */}}
+{{ range $sectionName, $config := .Site.Params.contentSections }}
+{{ if in $config.taxonomies $.Type }}
+{{ $currentSection = $sectionName }}
+{{ end }}
+{{ end }}
+
 {{ $sectionConfig := index .Site.Params.contentSections $currentSection }}
 
 {{/* Fallback to default blogs section if current section not configured */}}


### PR DESCRIPTION
## Summary
Adds a configurable system for managing multiple content sections (blogs, opinions, news, etc.) with their own taxonomies and section-aware features.

## What's New

### Dynamic Content Sections
- New `contentSections` configuration to define section-specific settings
- Each section can have custom footer titles, view-all button text, and associated taxonomies
- Footer automatically shows section-relevant recent posts (e.g., "Recent Opinions" when viewing opinion content)

### Section-Specific Taxonomies
- Support for prefixed taxonomies like `opinion_tags` and `opinion_categories`
- Taxonomy pages display clean titles (e.g., "Tags" instead of "Opinion Tags")
- Single pages auto-detect and display the correct tags based on content type

### Search Exclusion
- New `excludeFromSearch` front matter option to hide specific posts from search results

### Archetypes
- Custom archetypes for blogs and opinions with pre-configured front matter fields
- Opinions default to `excludeFromSearch: true`

### Documentation
- Added comprehensive guide for adding new content sections

## How to Add a New Section
1. Add section config with `recentTitle`, `viewAllText`, and `taxonomies`
2. Register taxonomies (optional)
3. Create content directory with [_index.md](cci:7://file:///Users/jairaj.kumar.admin/Library/CloudStorage/OneDrive-R3/Documents/pworks/me/content/opinions/_index.md:0:0-0:0)
4. Create matching archetype
5. Start creating posts with `hugo new {section}/post.md`